### PR TITLE
chore: rename from kLoop to compio-py

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "compio-py"
+version = "0.1.0"
+dependencies = [
+ "async-task",
+ "compio",
+ "compio-log",
+ "once_cell",
+ "pyo3",
+ "scoped-tls",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -218,19 +231,6 @@ dependencies = [
  "bytes",
  "io-uring",
  "rustix",
-]
-
-[[package]]
-name = "kLoop"
-version = "0.1.0"
-dependencies = [
- "async-task",
- "compio",
- "compio-log",
- "once_cell",
- "pyo3",
- "scoped-tls",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "kLoop"
+name = "compio-py"
 version = "0.1.0"
 edition = "2024"
 license = "Apache-2.0 OR MulanPSL-2.0"

--- a/README.md
+++ b/README.md
@@ -1,13 +1,10 @@
-# <img src="docs/logo.svg" height="40px" align="right">  kLoop
+# <img src="docs/logo.svg" height="40px" align="right">  compio-py
 
 High-performance Python `asyncio` alternative event loop powered by Rust's
-[`compio`](https://github.com/compio-rs/compio) library. "k" as in "completion"
-reflecting that `compio` drives completion-based I/O, or "k" as in "kernel"
-reflecting Linux kernel features like `io_uring` and kTLS.
+[`compio`](https://github.com/compio-rs/compio) library.
 
 [![中文](https://img.shields.io/badge/Zh-中文-informational?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAQCAYAAAAWGF8bAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAFKADAAQAAAABAAAAEAAAAABHXVY9AAABc0lEQVQ4EaWSOy8EURTHd+wDEY94JVtgg9BI1B6dQqHiE1CrRasT30DpC2hVQimiFkJWVsSj2U1EsmQH4/ff3CO3WDuDk/zmf8/jnntm7qRSMRZFUQ4WYSimNFmaRlsgq8F83K6WuALyva4mixbc+kfJcGqa7CqU4AjaocNpG5oHsx7qB3EqQRC8K4g/gazAMbFTBdbgL1Zh0w2EbnMVHdMrd4LZNotZmIZJKMAemC2z0MS6oDlYhzOQ6c3yGR5Fec4OGPvEHCmn3np+kfyT51+QH8afcbFLTfjgFVS9tZrpwC4v1k9M39w3NTQrBxSM4127SAmNoBt0Ma3QyHRwGUIYdQUh0+c0wZsLPKKH8AwvoHgNlmABZLtwBdqnP0DD9IEG2If6N0oz5SbYSfW4PYhvgNmUxU1JZGEEAsUyjPmB7lhBA1Xe7NMWpuzXa39fnC7lN1b/mZttSNLQv9XXZs2US9LwzjU5R+/d+n/CBx9I2uELeXrRajeDqHwAAAAASUVORK5CYII=)](README.zh.md)
-[![CI](https://img.shields.io/github/actions/workflow/status/fantix/kloop/test.yml?label=CI&logo=github)](https://github.com/fantix/kloop/actions/workflows/test.yml)
-[![downloads](https://img.shields.io/pypi/dm/kloop?logo=pypi&logoColor=white)](https://pypi.python.org/pypi/gino)
+[![CI](https://img.shields.io/github/actions/workflow/status/compio-rs/compio-py/test.yml?label=CI&logo=github)](https://github.com/compio-rs/compio-py/actions/workflows/test.yml)
 [![code quality](https://img.shields.io/codacy/grade/f2e97d6eb2554e87b3cd15aae8f6b1e0?logo=codacy)](https://app.codacy.com/gh/fantix/kloop/dashboard)
 [![license](https://img.shields.io/badge/license-Apache--2.0-success?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAgCAYAAAASYli2AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAGqSURBVHgBrVbtcYMwDFVy/V82KCMwAp2g2aDtJGSDZoPQDegE0AmSDUwngA1UKYggHBtwyLvTgcF66ONZCcAdQMSMrCEzZHGILzvHZJFaf+AYxxCyTDlmQm5k3cj1EEJ4Qjf085322UI4KrJrCTabTXFDKKmU8uUjWSLvfy2yWixWWbDf16g58tBGadWQsUc/GuZ6Es4YbpGK6ehewI9iLkIMiO7Up7z11AoctcOJyF6pObWOMMJBVy6wmI0rapv9EiGxt3T5nIiOETvePaN99LCTTCL3B0/tfALvYbCTWww4pFJ6HHe4HCXLppVgU0dKP2RvsBwJzESwQ3czfDj0dXRpzODydFkhe+a6nBTqMhPybabCrybSzaUcrVgtSrl2miPhbufqqyn6tWnQN6lxPIGbgHSNi4+FHal1tCDdHt+uh1zDs2ez/VtRy94/soJqVoEPOD4hjdTPrlkKIVANOaJ/VBVzPP2AZelwc2pJ7d2xl2WRw1JC5VQJKc/Ivkm8zkdaWwJ0zLdQbBVZBMOgWE8I3bSpYCU0YUI1OsNK3PPPYZ5QDnoND8A/4kV4DUnNfc8AAAAASUVORK5CYII=)](https://www.apache.org/licenses/LICENSE-2.0)
 [![license](https://img.shields.io/badge/license-MulanPSL--2.0-success?logo=opensourceinitiative&logoColor=white)](https://license.coscl.org.cn/MulanPSL2/)
@@ -27,7 +24,7 @@ uv sync
 Or switch to enable logging support:
 
 ```bash
-MATURIN_PEP517_ARGS="--features enable_log" uv sync --reinstall-package kloop
+MATURIN_PEP517_ARGS="--features enable_log" uv sync --reinstall-package compio
 ```
 
 ### Testing

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,12 +1,10 @@
-# <img src="docs/logo.svg" height="40px" align="right">  kLoop
+# <img src="docs/logo.svg" height="40px" align="right">  compio-py
 
 基于 Rust [`compio`](https://github.com/compio-rs/compio) 库的高性能 Python `asyncio`
-事件循环替代方案。“k”可以理解为“completion”（完成式），表示 `compio` 采用完成式 I/O
-模型；也可以理解为“kernel”（内核），代表它使用了 `io_uring` 和 kTLS 等 Linux 内核特性。
+事件循环替代方案。
 
 [![English](https://img.shields.io/badge/英文-English-informational?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABsAAAAQCAYAAADnEwSWAAAABGdBTUEAALGPC/xhBQAAADhlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAAqACAAQAAAABAAAAG6ADAAQAAAABAAAAEAAAAACiF0fSAAABJUlEQVQ4EWP8//8/MwMDAysQEw0YGRl/EK0YWSHQsgogJgX8RNZPCpuJFMWUqqWrZSw4XBsCFL+FQ+4/DnEUYWC8gNKCEDB+X8MlgIKVWCJMD64ADwOorwmIHyNhdyDbFYgPAfFXIAaBV0CcCTIG5DNsLo0GKnDEYc8+oGsvQ+UEgLQMkrpYIDsSiJGjRxTInwY07wmuYCxDMgCdmQUUgFmGLheNLoDEzwG5gBFJgFQmNr3ZQEPsgfgImmEquHy2BajwHZpiGPcmjAGk0aPgCDCIp4HkgcHWA6RsQGwoEMEVZ9VATZdgqkig7yKp/YjEBjORIxJdjhw+3tIFVzCGAoPBEo9ta4E+f4NHHqsULstqsKpGCJ4BMkm2jNrBiHAOFhZdLQMA8pKhkQYZiokAAAAASUVORK5CYII=)](README.md)
-[![CI](https://img.shields.io/github/actions/workflow/status/fantix/kloop/test.yml?label=CI&logo=github)](https://github.com/fantix/kloop/actions/workflows/test.yml)
-[![下载](https://img.shields.io/pypi/dm/kloop?logo=pypi&logoColor=white&label=下载)](https://pypi.python.org/pypi/gino)
+[![CI](https://img.shields.io/github/actions/workflow/status/compio-rs/compio-py/test.yml?label=CI&logo=github)](https://github.com/compio-rs/compio-py/actions/workflows/test.yml)
 [![质量](https://img.shields.io/codacy/grade/f2e97d6eb2554e87b3cd15aae8f6b1e0?logo=codacy&label=质量)](https://app.codacy.com/gh/fantix/kloop/dashboard)
 [![许可](https://img.shields.io/badge/许可-Apache--2.0-success?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAgCAYAAAASYli2AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAGqSURBVHgBrVbtcYMwDFVy/V82KCMwAp2g2aDtJGSDZoPQDegE0AmSDUwngA1UKYggHBtwyLvTgcF66ONZCcAdQMSMrCEzZHGILzvHZJFaf+AYxxCyTDlmQm5k3cj1EEJ4Qjf085322UI4KrJrCTabTXFDKKmU8uUjWSLvfy2yWixWWbDf16g58tBGadWQsUc/GuZ6Es4YbpGK6ehewI9iLkIMiO7Up7z11AoctcOJyF6pObWOMMJBVy6wmI0rapv9EiGxt3T5nIiOETvePaN99LCTTCL3B0/tfALvYbCTWww4pFJ6HHe4HCXLppVgU0dKP2RvsBwJzESwQ3czfDj0dXRpzODydFkhe+a6nBTqMhPybabCrybSzaUcrVgtSrl2miPhbufqqyn6tWnQN6lxPIGbgHSNi4+FHal1tCDdHt+uh1zDs2ez/VtRy94/soJqVoEPOD4hjdTPrlkKIVANOaJ/VBVzPP2AZelwc2pJ7d2xl2WRw1JC5VQJKc/Ivkm8zkdaWwJ0zLdQbBVZBMOgWE8I3bSpYCU0YUI1OsNK3PPPYZ5QDnoND8A/4kV4DUnNfc8AAAAASUVORK5CYII=)](https://www.apache.org/licenses/LICENSE-2.0)
 [![许可](https://img.shields.io/badge/许可-MulanPSL--2.0-success?logo=opensourceinitiative&logoColor=white)](https://license.coscl.org.cn/MulanPSL2/)
@@ -26,7 +24,7 @@ uv sync
 如需启用调试日志：
 
 ```bash
-MATURIN_PEP517_ARGS="--features enable_log" uv sync --reinstall-package kloop
+MATURIN_PEP517_ARGS="--features enable_log" uv sync --reinstall-package compio
 ```
 
 ### 运行测试

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "kLoop"
+name = "compio"
 version = "0.1.0"
 description = "An asyncio event loop implementation powered by Rust's compio."
 readme = "README.md"


### PR DESCRIPTION
PyPI package name shall be simply `compio`