### PR TITLE
feat: add basic socket API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -50,25 +56,28 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 [[package]]
 name = "compio"
 version = "0.18.0"
-source = "git+https://github.com/compio-rs/compio.git?rev=8decea5007df7796abd85c5fa7c0c819915dfde8#8decea5007df7796abd85c5fa7c0c819915dfde8"
+source = "git+https://github.com/compio-rs/compio.git?rev=8cf1b4db78c93f37d462b85bd1f445caa7fca4d5#8cf1b4db78c93f37d462b85bd1f445caa7fca4d5"
 dependencies = [
  "compio-buf",
  "compio-driver",
+ "compio-io",
  "compio-log",
 ]
 
 [[package]]
 name = "compio-buf"
 version = "0.8.0"
-source = "git+https://github.com/compio-rs/compio.git?rev=8decea5007df7796abd85c5fa7c0c819915dfde8#8decea5007df7796abd85c5fa7c0c819915dfde8"
+source = "git+https://github.com/compio-rs/compio.git?rev=8cf1b4db78c93f37d462b85bd1f445caa7fca4d5#8cf1b4db78c93f37d462b85bd1f445caa7fca4d5"
 dependencies = [
+ "arrayvec",
+ "bytes",
  "libc",
 ]
 
 [[package]]
 name = "compio-driver"
 version = "0.11.1"
-source = "git+https://github.com/compio-rs/compio.git?rev=8decea5007df7796abd85c5fa7c0c819915dfde8#8decea5007df7796abd85c5fa7c0c819915dfde8"
+source = "git+https://github.com/compio-rs/compio.git?rev=8cf1b4db78c93f37d462b85bd1f445caa7fca4d5#8cf1b4db78c93f37d462b85bd1f445caa7fca4d5"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -94,9 +103,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "compio-io"
+version = "0.9.0"
+source = "git+https://github.com/compio-rs/compio.git?rev=8cf1b4db78c93f37d462b85bd1f445caa7fca4d5#8cf1b4db78c93f37d462b85bd1f445caa7fca4d5"
+dependencies = [
+ "compio-buf",
+ "futures-util",
+ "paste",
+ "synchrony",
+]
+
+[[package]]
 name = "compio-log"
 version = "0.1.0"
-source = "git+https://github.com/compio-rs/compio.git?rev=8decea5007df7796abd85c5fa7c0c819915dfde8#8decea5007df7796abd85c5fa7c0c819915dfde8"
+source = "git+https://github.com/compio-rs/compio.git?rev=8cf1b4db78c93f37d462b85bd1f445caa7fca4d5#8cf1b4db78c93f37d462b85bd1f445caa7fca4d5"
 dependencies = [
  "tracing",
 ]
@@ -111,6 +131,7 @@ dependencies = [
  "once_cell",
  "pyo3",
  "scoped-tls",
+ "socket2",
  "tracing-subscriber",
 ]
 
@@ -175,6 +196,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
 name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,6 +215,7 @@ checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-macro",
+ "futures-sink",
  "futures-task",
  "pin-project-lite",
  "slab",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,14 @@ once_cell = "1.21.3"
 scoped-tls = "1.0.1"
 async-task = { version = "4.7.1", default-features = false }
 tracing-subscriber = { version = "0.3", optional = true, features = ["env-filter"] }
+socket2 = "0.6.2"
 
 [dependencies.compio]
 git = "https://github.com/compio-rs/compio.git"
-rev = "8decea5007df7796abd85c5fa7c0c819915dfde8"
+rev = "8cf1b4db78c93f37d462b85bd1f445caa7fca4d5"
 default-features = false
-features = ["io-uring", "polling"]
+features = ["io-uring", "polling", "io"]
 
 [dependencies.compio-log]
 git = "https://github.com/compio-rs/compio.git"
-rev = "8decea5007df7796abd85c5fa7c0c819915dfde8"
+rev = "8cf1b4db78c93f37d462b85bd1f445caa7fca4d5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ license-files = ["LICENSE.Apache-2.0", "LICENSE.MulanPSL-2.0"]
 dev = [
     "mypy>=1.19.0",
     "ruff>=0.14.7",
+    "typing-extensions>=4.15.0; python_version < '3.12'",
 ]
 
 [tool.maturin]

--- a/src/compio/__init__.py
+++ b/src/compio/__init__.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0 OR MulanPSL-2.0
 # Copyright 2025 Fantix King
 
-from ._core import Handle, TimerHandle
+from ._core import Handle, Socket, TimerHandle
 from .loop import CompioLoop, DriverType
 
-__all__ = ["CompioLoop", "DriverType", "Handle", "TimerHandle"]
+__all__ = ["CompioLoop", "DriverType", "Handle", "Socket", "TimerHandle"]

--- a/src/compio/_core.pyi
+++ b/src/compio/_core.pyi
@@ -3,10 +3,19 @@
 
 from __future__ import annotations
 from collections.abc import Callable
-from typing import Any, Optional, TypeVarTuple, Unpack
+from typing import Any, Optional, TypeAlias, TypeVarTuple, Unpack
 
 import asyncio
+import socket
+import sys
 from contextvars import Context
+
+if sys.version_info >= (3, 12):
+    from collections.abc import Buffer
+else:
+    from typing_extensions import Buffer
+
+_Address: TypeAlias = tuple[Any, ...]
 
 class Handle:
     def cancel(self) -> None: ...
@@ -55,3 +64,16 @@ class CompioLoop:
     def run_forever(self) -> None: ...
     def stop(self) -> None: ...
     def close(self) -> None: ...
+    def create_socket(
+        self,
+        family: socket.AddressFamily | int = -1,
+        type: socket.SocketKind | int = -1,
+        proto: int = -1,
+    ) -> Socket: ...
+
+class Socket:
+    async def connect(self, address: _Address, /) -> None: ...
+    async def recv(self, bufsize: int, flags: int = 0, /) -> bytes: ...
+    async def send(self, data: Buffer, flags: int = 0, /) -> int: ...
+    async def shutdown(self, how: int, /) -> None: ...
+    async def close(self) -> None: ...

--- a/src/import.rs
+++ b/src/import.rs
@@ -183,16 +183,29 @@ module!(contextvars {
 });
 
 module!(socket {
-    use pyo3::types::{PyDict, PyTuple};
+    use pyo3::{types::{PyDict, PyTuple}, call::PyCallArgs};
 
-    pub fn getaddrinfo(
-        py: Python,
-        args: Py<PyTuple>,
+    pub fn shut_wr(py: Python) -> PyResult<i32> {
+        getattr!(py, socket, "SHUT_WR").extract()
+    }
+
+    pub fn shut_rd(py: Python) -> PyResult<i32> {
+        getattr!(py, socket, "SHUT_RD").extract()
+    }
+
+    pub fn shut_rdwr(py: Python) -> PyResult<i32> {
+        getattr!(py, socket, "SHUT_RDWR").extract()
+    }
+
+    pub fn getaddrinfo<'py, A>(
+        py: Python<'py>,
+        args: A,
         kwargs: Option<Py<PyDict>>,
-    ) -> PyResult<Py<PyAny>> {
+    ) -> PyResult<Bound<'py, PyAny>> where
+        A: PyCallArgs<'py>,
+    {
         getattr!(py, socket, "getaddrinfo")
             .call(args, kwargs.as_ref().map(|d| d.bind(py)))
-            .map(|r| r.unbind())
     }
 
     pub fn getnameinfo(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ mod import;
 mod owned;
 mod runtime;
 mod send_wrapper;
+mod socket;
 mod thread;
 
 /// A Python module implemented in Rust. The name of this module must match
@@ -33,5 +34,6 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     event_loop::register(m)?;
     handle::register(m)?;
+    socket::register(m)?;
     Ok(())
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -457,6 +457,22 @@ impl<S: AsFd> Attacher<S> {
     }
 }
 
+impl<S> IntoInner for Attacher<S> {
+    type Inner = SharedFd<S>;
+
+    fn into_inner(self) -> Self::Inner {
+        self.source
+    }
+}
+
+impl<S> Clone for Attacher<S> {
+    fn clone(&self) -> Self {
+        Self {
+            source: self.source.clone(),
+        }
+    }
+}
+
 #[cfg(windows)]
 impl<S: std::os::windows::io::FromRawHandle> std::os::windows::io::FromRawHandle for Attacher<S> {
     unsafe fn from_raw_handle(handle: std::os::windows::io::RawHandle) -> Self {

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -1,0 +1,331 @@
+// SPDX-License-Identifier: Apache-2.0 OR MulanPSL-2.0
+// Copyright 2026 Fantix King
+
+use std::{
+    io,
+    net::{Ipv4Addr, Shutdown, SocketAddr, SocketAddrV4},
+};
+
+use compio::{
+    buf::{BufResult, IntoInner, IoBuf, IoBufMut, buf_try},
+    driver::{
+        AsRawFd, ToSharedFd, impl_raw_fd,
+        op::{BufResultExt, CloseSocket, Connect, Recv, Send, ShutdownSocket},
+    },
+};
+use pyo3::{
+    IntoPyObjectExt,
+    buffer::PyBuffer,
+    exceptions::{PyOSError, PyTypeError, PyValueError},
+    prelude::*,
+    types::{PyByteArray, PyBytes, PyList, PyTuple},
+};
+use socket2::{Domain, Protocol, SockAddr, Socket as Socket2, Type};
+
+use crate::{
+    event_loop::CompioLoop,
+    import,
+    runtime::{self, Attacher},
+};
+
+#[pyclass(unsendable, name = "Socket")]
+pub struct PySocket {
+    pyloop: Py<CompioLoop>,
+    domain: Domain,
+    ty: Type,
+    protocol: Option<Protocol>,
+    inner: Option<Socket>,
+    bound: bool,
+}
+
+impl PySocket {
+    pub async fn new(
+        pyloop: Py<CompioLoop>,
+        domain: Domain,
+        ty: Type,
+        protocol: Option<Protocol>,
+    ) -> PyResult<Py<PyAny>> {
+        let inner = Some(Socket::new(domain, ty, protocol).await?);
+        Python::attach(|py| {
+            Bound::new(
+                py,
+                Self {
+                    pyloop,
+                    domain,
+                    ty,
+                    protocol,
+                    inner,
+                    bound: false,
+                },
+            )?
+            .into_py_any(py)
+        })
+    }
+
+    #[inline]
+    fn inner(&self) -> PyResult<&Socket> {
+        self.inner
+            .as_ref()
+            .ok_or_else(|| PyOSError::new_err("socket is closed"))
+    }
+}
+
+#[pymethods]
+impl PySocket {
+    fn __repr__(&self) -> PyResult<String> {
+        if let Some(inner) = &self.inner {
+            let fd = inner.as_raw_fd();
+            let family = i32::from(self.domain);
+            let ty = i32::from(self.ty);
+            let proto = self.protocol.map(i32::from).unwrap_or_default();
+            let laddr = match inner.socket.local_addr() {
+                Ok(addr) => match addr.as_socket() {
+                    Some(addr) => format!(", laddr={addr}"),
+                    None => unimplemented!("unix socket"),
+                },
+                Err(_) => "".to_string(),
+            };
+            Ok(format!(
+                "<compio.Socket fd={fd:?}, family={family}, type={ty}, protocol={proto}{laddr}>"
+            ))
+        } else {
+            Ok("<compio.Socket (closed)>".to_string())
+        }
+    }
+
+    #[pyo3(signature = (address, /))]
+    fn connect<'py>(&mut self, py: Python<'py>, address: Py<PyAny>) -> PyResult<Bound<'py, PyAny>> {
+        self.pyloop.bind(py).borrow().spawn_py(py, async move {
+            let Some(inner) = &self.inner else {
+                return Err(PyOSError::new_err("socket is closed"));
+            };
+            match self.domain {
+                Domain::IPV4 => {
+                    let (result, port) = Python::attach(|py| {
+                        let (host, port): (Bound<PyAny>, u16) = address.extract(py)?;
+                        idna_converter(&host, |name| {
+                            // https://github.com/rust-lang/rust/issues/101035
+                            match str::from_utf8(name)?.parse::<Ipv4Addr>() {
+                                Ok(ip) => Ok((Ok(ip), port)),
+                                Err(_) => Ok((Err(name.to_owned()), port)),
+                            }
+                        })
+                    })?;
+                    let ip = match result {
+                        Ok(ip) => ip,
+                        Err(name) => name_to_ip(name, self.domain).await?.parse()?,
+                    };
+                    if cfg!(windows) && !self.bound {
+                        inner
+                            .socket
+                            .bind(&SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0).into())?;
+                        self.bound = true;
+                    }
+                    let addr = SocketAddr::new(ip.into(), port).into();
+                    inner.connect_async(&addr).await?;
+                    self.bound = true;
+                }
+                _ => unimplemented!(),
+            };
+            Python::attach(|py| py.None().into_py_any(py))
+        })
+    }
+
+    #[pyo3(signature = (bufsize, flags = 0, /))]
+    fn recv<'py>(
+        &self,
+        py: Python<'py>,
+        bufsize: usize,
+        flags: i32,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        self.pyloop.bind(py).borrow().spawn_py(py, async move {
+            let inner = self.inner()?;
+            let buf = Vec::with_capacity(bufsize);
+            let result = inner.recv(buf, flags).await;
+            let bytes_read = result.0?;
+            let mut buf = result.1;
+            buf.truncate(bytes_read);
+            Python::attach(|py| PyBytes::new(py, &buf).into_py_any(py))
+        })
+    }
+
+    #[pyo3(signature = (data, flags = 0, /))]
+    fn send<'py>(
+        &self,
+        py: Python<'py>,
+        data: Py<PyAny>,
+        flags: i32,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        self.pyloop.bind(py).borrow().spawn_py(py, async move {
+            let inner = self.inner()?;
+            let buf = Python::attach(|py| {
+                let pybuf: PyBuffer<u8> = PyBuffer::get(data.bind(py))?;
+                if pybuf.is_c_contiguous() {
+                    let ptr = pybuf.buf_ptr() as *mut u8;
+                    let len = pybuf.len_bytes();
+                    Ok(Ok(unsafe { std::slice::from_raw_parts(ptr, len) }))
+                } else {
+                    pybuf.to_vec(py).map(|buf| Err(buf))
+                }
+            })?;
+            let bytes_written = match buf {
+                Ok(buf) => inner.send(buf, flags).await.0?,
+                Err(buf) => inner.send(buf, flags).await.0?,
+            };
+            drop(data);
+            Python::attach(|py| bytes_written.into_py_any(py))
+        })
+    }
+
+    #[pyo3(signature = (how, /))]
+    fn shutdown<'py>(&self, py: Python<'py>, how: i32) -> PyResult<Bound<'py, PyAny>> {
+        self.pyloop.bind(py).borrow().spawn_py(py, async move {
+            let inner = self.inner()?;
+            let how = Python::attach(|py| {
+                if how == import::socket::shut_wr(py)? {
+                    Ok(Shutdown::Write)
+                } else if how == import::socket::shut_rd(py)? {
+                    Ok(Shutdown::Read)
+                } else if how == import::socket::shut_rdwr(py)? {
+                    Ok(Shutdown::Both)
+                } else {
+                    return Err(PyValueError::new_err(format!(
+                        "invalid shutdown how: {how}"
+                    )));
+                }
+            })?;
+            inner.shutdown(how).await?;
+            Python::attach(|py| py.None().into_py_any(py))
+        })
+    }
+
+    fn close<'py>(&mut self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        self.pyloop.bind(py).borrow().spawn_py(py, async move {
+            if let Some(inner) = self.inner.take() {
+                inner.close().await?;
+            };
+            Python::attach(|py| py.None().into_py_any(py))
+        })
+    }
+}
+
+async fn name_to_ip(name: Vec<u8>, family: impl Into<i32>) -> PyResult<String> {
+    let family = family.into();
+    runtime::asyncify(move || {
+        Python::attach(|py| {
+            let args = (name, py.None(), family);
+            let result_list: Bound<PyList> =
+                import::socket::getaddrinfo(py, args, None)?.cast_into()?;
+            let result: Bound<PyTuple> = result_list.get_item(0)?.cast_into()?;
+            let addr: Bound<PyTuple> = result.get_item(result.len() - 1)?.cast_into()?;
+            addr.get_item(0)?.extract()
+        })
+    })
+    .await
+}
+
+fn idna_converter<T, F>(obj: &Bound<PyAny>, f: F) -> PyResult<T>
+where
+    F: FnOnce(&[u8]) -> PyResult<T>,
+{
+    if let Ok(bytes) = obj.cast::<PyBytes>() {
+        f(bytes.as_bytes())
+    } else if let Ok(bytes) = obj.cast::<PyByteArray>() {
+        f(unsafe { bytes.as_bytes() })
+    } else if let Ok(str) = obj.extract::<&str>() {
+        if str.is_ascii() {
+            f(str.as_bytes())
+        } else {
+            f(obj
+                .call_method1("encode", ("idna",))?
+                .cast::<PyBytes>()?
+                .as_bytes())
+        }
+    } else {
+        Err(PyTypeError::new_err(format!(
+            "str, bytes or bytearray expected, not {}",
+            obj.get_type()
+        )))
+    }
+}
+
+pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<PySocket>()?;
+    Ok(())
+}
+
+// Socket is copied and modified from compio-net:
+// https://github.com/compio-rs/compio/blob/8cf1b4db78c93f37d462b85bd1f445caa7fca4d5/compio-net/src/socket.rs
+// Copyright (c) 2023 Berrysoft
+
+#[derive(Clone)]
+struct Socket {
+    socket: Attacher<Socket2>,
+}
+
+impl Socket {
+    fn from_socket2(socket: Socket2) -> io::Result<Self> {
+        let socket = Attacher::new(socket)?;
+        Ok(Self { socket })
+    }
+
+    async fn new(domain: Domain, ty: Type, protocol: Option<Protocol>) -> io::Result<Self> {
+        Self::from_socket2({
+            #[cfg(windows)]
+            {
+                runtime::asyncify(move || Socket2::new(domain, ty, protocol)).await?
+            }
+            #[cfg(unix)]
+            {
+                use compio::driver::op::CreateSocket;
+
+                let op = CreateSocket::new(
+                    domain.into(),
+                    ty.into(),
+                    protocol.map(|p| p.into()).unwrap_or_default(),
+                );
+                let (_, op) = buf_try!(@try runtime::execute(op).await);
+                op.into_inner()
+            }
+        })
+    }
+
+    async fn connect_async(&self, addr: &SockAddr) -> io::Result<()> {
+        let op = Connect::new(self.to_shared_fd(), addr.clone());
+        let (_, _op) = buf_try!(@try runtime::execute(op).await);
+        #[cfg(windows)]
+        _op.update_context()?;
+        Ok(())
+    }
+
+    async fn recv<B: IoBufMut>(&self, buffer: B, flags: i32) -> BufResult<usize, B> {
+        let fd = self.to_shared_fd();
+        let op = Recv::new(fd, buffer, flags);
+        let res = runtime::execute(op).await.into_inner();
+        unsafe { res.map_advanced() }
+    }
+
+    async fn send<T: IoBuf>(&self, buffer: T, flags: i32) -> BufResult<usize, T> {
+        let fd = self.to_shared_fd();
+        let op = Send::new(fd, buffer, flags);
+        runtime::execute(op).await.into_inner()
+    }
+
+    async fn shutdown(&self, how: Shutdown) -> io::Result<()> {
+        let fd = self.to_shared_fd();
+        let op = ShutdownSocket::new(fd, how);
+        runtime::execute(op).await.0?;
+        Ok(())
+    }
+
+    async fn close(self) -> io::Result<()> {
+        let fd = self.socket.into_inner().take().await;
+        if let Some(fd) = fd {
+            let op = CloseSocket::new(fd.into());
+            runtime::execute(op).await.0?;
+        }
+        Ok(())
+    }
+}
+
+impl_raw_fd!(Socket, Socket2, socket, socket);


### PR DESCRIPTION
Given the completion-based nature of `compio`, the low-level Python API for I/O in `compio-py` can be async sockets instead of protocols and transports.

Usage:

```python
import asyncio, socket
import compio

loop = compio.CompioLoop()
asyncio._set_running_loop(loop)

async def main():
    try:
        s = await loop.create_socket(socket.AF_INET)
        print("socket created:", s)

        await s.connect(("www.google.com", 80))

        bytes_sent = await s.send(b"GET / HTTP/1.0\r\nHost: www.google.com\r\n\r\n")
        print(f"sent {bytes_sent} bytes")

        data = await s.recv(65536)
        print(f"received {len(data)} bytes")
        print(data[:128])

        await s.shutdown(socket.SHUT_WR)
        await s.close()

    finally:
        loop.stop()

task = asyncio.Task(main(), loop=loop)
loop.run_forever()
```