### PR TITLE
feat: replace async_task with compio-executor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,7 +132,7 @@ dependencies = [
 [[package]]
 name = "compio"
 version = "0.18.0"
-source = "git+https://github.com/compio-rs/compio.git?rev=92127da50b383be53f7a5364ee818bf3952ac17f#92127da50b383be53f7a5364ee818bf3952ac17f"
+source = "git+https://github.com/compio-rs/compio.git?rev=708499c3f4bb4f57402782b326c7edc7b4fa8b4e#708499c3f4bb4f57402782b326c7edc7b4fa8b4e"
 dependencies = [
  "compio-buf",
  "compio-driver",
@@ -140,7 +146,7 @@ dependencies = [
 [[package]]
 name = "compio-buf"
 version = "0.8.0"
-source = "git+https://github.com/compio-rs/compio.git?rev=92127da50b383be53f7a5364ee818bf3952ac17f#92127da50b383be53f7a5364ee818bf3952ac17f"
+source = "git+https://github.com/compio-rs/compio.git?rev=708499c3f4bb4f57402782b326c7edc7b4fa8b4e#708499c3f4bb4f57402782b326c7edc7b4fa8b4e"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -150,24 +156,23 @@ dependencies = [
 [[package]]
 name = "compio-driver"
 version = "0.11.1"
-source = "git+https://github.com/compio-rs/compio.git?rev=92127da50b383be53f7a5364ee818bf3952ac17f#92127da50b383be53f7a5364ee818bf3952ac17f"
+source = "git+https://github.com/compio-rs/compio.git?rev=708499c3f4bb4f57402782b326c7edc7b4fa8b4e#708499c3f4bb4f57402782b326c7edc7b4fa8b4e"
 dependencies = [
  "bitflags",
  "cfg-if",
  "cfg_aliases",
  "compio-buf",
  "compio-log",
+ "compio-send-wrapper",
  "crossbeam-queue",
  "flume",
  "futures-util",
  "io-uring",
- "io_uring_buf_ring",
  "libc",
+ "nix",
  "once_cell",
- "paste",
- "pin-project-lite",
+ "pastey",
  "polling",
- "slab",
  "smallvec",
  "socket2",
  "synchrony",
@@ -176,20 +181,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "compio-executor"
+version = "0.1.0"
+source = "git+https://github.com/compio-rs/compio.git?rev=708499c3f4bb4f57402782b326c7edc7b4fa8b4e#708499c3f4bb4f57402782b326c7edc7b4fa8b4e"
+dependencies = [
+ "compio-log",
+ "compio-send-wrapper",
+ "crossfire",
+ "slotmap",
+]
+
+[[package]]
 name = "compio-io"
 version = "0.9.0"
-source = "git+https://github.com/compio-rs/compio.git?rev=92127da50b383be53f7a5364ee818bf3952ac17f#92127da50b383be53f7a5364ee818bf3952ac17f"
+source = "git+https://github.com/compio-rs/compio.git?rev=708499c3f4bb4f57402782b326c7edc7b4fa8b4e#708499c3f4bb4f57402782b326c7edc7b4fa8b4e"
 dependencies = [
+ "bytemuck",
+ "cfg-if",
  "compio-buf",
  "futures-util",
- "paste",
+ "libc",
+ "pastey",
+ "pin-project-lite",
  "synchrony",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "compio-log"
 version = "0.1.0"
-source = "git+https://github.com/compio-rs/compio.git?rev=92127da50b383be53f7a5364ee818bf3952ac17f#92127da50b383be53f7a5364ee818bf3952ac17f"
+source = "git+https://github.com/compio-rs/compio.git?rev=708499c3f4bb4f57402782b326c7edc7b4fa8b4e#708499c3f4bb4f57402782b326c7edc7b4fa8b4e"
 dependencies = [
  "tracing",
 ]
@@ -197,7 +218,7 @@ dependencies = [
 [[package]]
 name = "compio-net"
 version = "0.11.0"
-source = "git+https://github.com/compio-rs/compio.git?rev=92127da50b383be53f7a5364ee818bf3952ac17f#92127da50b383be53f7a5364ee818bf3952ac17f"
+source = "git+https://github.com/compio-rs/compio.git?rev=708499c3f4bb4f57402782b326c7edc7b4fa8b4e#708499c3f4bb4f57402782b326c7edc7b4fa8b4e"
 dependencies = [
  "cfg-if",
  "compio-buf",
@@ -205,6 +226,7 @@ dependencies = [
  "compio-io",
  "compio-runtime",
  "either",
+ "futures-util",
  "libc",
  "once_cell",
  "socket2",
@@ -245,7 +267,7 @@ dependencies = [
 [[package]]
 name = "compio-quic"
 version = "0.7.0"
-source = "git+https://github.com/compio-rs/compio.git?rev=92127da50b383be53f7a5364ee818bf3952ac17f#92127da50b383be53f7a5364ee818bf3952ac17f"
+source = "git+https://github.com/compio-rs/compio.git?rev=708499c3f4bb4f57402782b326c7edc7b4fa8b4e#708499c3f4bb4f57402782b326c7edc7b4fa8b4e"
 dependencies = [
  "cfg_aliases",
  "compio-buf",
@@ -267,30 +289,33 @@ dependencies = [
 [[package]]
 name = "compio-runtime"
 version = "0.11.0"
-source = "git+https://github.com/compio-rs/compio.git?rev=92127da50b383be53f7a5364ee818bf3952ac17f#92127da50b383be53f7a5364ee818bf3952ac17f"
+source = "git+https://github.com/compio-rs/compio.git?rev=708499c3f4bb4f57402782b326c7edc7b4fa8b4e#708499c3f4bb4f57402782b326c7edc7b4fa8b4e"
 dependencies = [
- "async-task",
  "cfg-if",
  "compio-buf",
  "compio-driver",
+ "compio-executor",
  "compio-log",
+ "compio-send-wrapper",
  "core_affinity",
- "crossbeam-queue",
  "futures-util",
  "libc",
- "once_cell",
  "pin-project-lite",
  "scoped-tls",
- "slab",
- "socket2",
  "synchrony",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
+name = "compio-send-wrapper"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4b20d9264c5c445ffee1c773b1d5ce7461fea060944424d126ac0853126edf2"
+
+[[package]]
 name = "compio-tls"
 version = "0.9.0"
-source = "git+https://github.com/compio-rs/compio.git?rev=92127da50b383be53f7a5364ee818bf3952ac17f#92127da50b383be53f7a5364ee818bf3952ac17f"
+source = "git+https://github.com/compio-rs/compio.git?rev=708499c3f4bb4f57402782b326c7edc7b4fa8b4e#708499c3f4bb4f57402782b326c7edc7b4fa8b4e"
 dependencies = [
  "compio-buf",
  "compio-io",
@@ -303,7 +328,7 @@ dependencies = [
 [[package]]
 name = "compio-ws"
 version = "0.3.0"
-source = "git+https://github.com/compio-rs/compio.git?rev=92127da50b383be53f7a5364ee818bf3952ac17f#92127da50b383be53f7a5364ee818bf3952ac17f"
+source = "git+https://github.com/compio-rs/compio.git?rev=708499c3f4bb4f57402782b326c7edc7b4fa8b4e#708499c3f4bb4f57402782b326c7edc7b4fa8b4e"
 dependencies = [
  "compio-buf",
  "compio-io",
@@ -362,6 +387,18 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossfire"
+version = "3.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0042e53977a94d5d10de04ce7eb6016aa212c08e83ea202f7a9f102ff104303"
+dependencies = [
+ "crossbeam-utils",
+ "futures-core",
+ "parking_lot",
+ "smallvec",
+]
 
 [[package]]
 name = "crypto-common"
@@ -521,6 +558,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,17 +668,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "io_uring_buf_ring"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1838759bb8c2f24cf05a35429d83145c4aa6af43f8ad38477295e12a7320a80e"
-dependencies = [
- "bytes",
- "io-uring",
- "rustix",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,6 +733,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "pin-utils",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,6 +766,18 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "no-std-compat"
@@ -744,10 +811,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "paste"
-version = "1.0.15"
+name = "parking_lot"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
 
 [[package]]
 name = "pbkdf2"
@@ -793,6 +883,12 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs5"
@@ -989,6 +1085,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1176,6 +1281,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1229,13 +1343,14 @@ dependencies = [
 
 [[package]]
 name = "synchrony"
-version = "0.1.4"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86246561e65786098f4dbe4d95bd7550ec541ff83921ab878e3b51c615735673"
+checksum = "c174d82fd56da8214ec095cfe4568e59e5ccb49d060e70c2f98e3ba352b23e45"
 dependencies = [
  "event-listener",
  "futures-util",
  "local-event",
+ "loom",
 ]
 
 [[package]]
@@ -1246,9 +1361,12 @@ checksum = "b1dd07eb858a2067e2f3c7155d54e929265c264e6f37efe3ee7a8d1b5a1dd0ba"
 
 [[package]]
 name = "thin-cell"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4164c6c316ba9733b0ab021e7f9852c788a4b991b49c25820f1be48e1d41345b"
+checksum = "7aa3372b7ae046fe560e0b4bc1312f5ad17adaea11a1cf45d5ca30664e3e50f1"
+dependencies = [
+ "synchrony",
+]
 
 [[package]]
 name = "thiserror"
@@ -1345,9 +1463,9 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -1359,7 +1477,6 @@ dependencies = [
  "rustls-pki-types",
  "sha1",
  "thiserror",
- "utf-8",
 ]
 
 [[package]]
@@ -1379,12 +1496,6 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "valuable"
@@ -1501,6 +1612,15 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,12 +29,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,7 +126,7 @@ dependencies = [
 [[package]]
 name = "compio"
 version = "0.18.0"
-source = "git+https://github.com/compio-rs/compio.git?rev=708499c3f4bb4f57402782b326c7edc7b4fa8b4e#708499c3f4bb4f57402782b326c7edc7b4fa8b4e"
+source = "git+https://github.com/compio-rs/compio.git?rev=54e801c3f17f9c82e79d24be65bd24c5b05056eb#54e801c3f17f9c82e79d24be65bd24c5b05056eb"
 dependencies = [
  "compio-buf",
  "compio-driver",
@@ -146,7 +140,7 @@ dependencies = [
 [[package]]
 name = "compio-buf"
 version = "0.8.0"
-source = "git+https://github.com/compio-rs/compio.git?rev=708499c3f4bb4f57402782b326c7edc7b4fa8b4e#708499c3f4bb4f57402782b326c7edc7b4fa8b4e"
+source = "git+https://github.com/compio-rs/compio.git?rev=54e801c3f17f9c82e79d24be65bd24c5b05056eb#54e801c3f17f9c82e79d24be65bd24c5b05056eb"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -156,7 +150,7 @@ dependencies = [
 [[package]]
 name = "compio-driver"
 version = "0.11.1"
-source = "git+https://github.com/compio-rs/compio.git?rev=708499c3f4bb4f57402782b326c7edc7b4fa8b4e#708499c3f4bb4f57402782b326c7edc7b4fa8b4e"
+source = "git+https://github.com/compio-rs/compio.git?rev=54e801c3f17f9c82e79d24be65bd24c5b05056eb#54e801c3f17f9c82e79d24be65bd24c5b05056eb"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -183,18 +177,20 @@ dependencies = [
 [[package]]
 name = "compio-executor"
 version = "0.1.0"
-source = "git+https://github.com/compio-rs/compio.git?rev=708499c3f4bb4f57402782b326c7edc7b4fa8b4e#708499c3f4bb4f57402782b326c7edc7b4fa8b4e"
+source = "git+https://github.com/compio-rs/compio.git?rev=54e801c3f17f9c82e79d24be65bd24c5b05056eb#54e801c3f17f9c82e79d24be65bd24c5b05056eb"
 dependencies = [
+ "cfg-if",
  "compio-log",
  "compio-send-wrapper",
- "crossfire",
+ "crossbeam-queue",
+ "loom",
  "slotmap",
 ]
 
 [[package]]
 name = "compio-io"
 version = "0.9.0"
-source = "git+https://github.com/compio-rs/compio.git?rev=708499c3f4bb4f57402782b326c7edc7b4fa8b4e#708499c3f4bb4f57402782b326c7edc7b4fa8b4e"
+source = "git+https://github.com/compio-rs/compio.git?rev=54e801c3f17f9c82e79d24be65bd24c5b05056eb#54e801c3f17f9c82e79d24be65bd24c5b05056eb"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -210,7 +206,7 @@ dependencies = [
 [[package]]
 name = "compio-log"
 version = "0.1.0"
-source = "git+https://github.com/compio-rs/compio.git?rev=708499c3f4bb4f57402782b326c7edc7b4fa8b4e#708499c3f4bb4f57402782b326c7edc7b4fa8b4e"
+source = "git+https://github.com/compio-rs/compio.git?rev=54e801c3f17f9c82e79d24be65bd24c5b05056eb#54e801c3f17f9c82e79d24be65bd24c5b05056eb"
 dependencies = [
  "tracing",
 ]
@@ -218,7 +214,7 @@ dependencies = [
 [[package]]
 name = "compio-net"
 version = "0.11.0"
-source = "git+https://github.com/compio-rs/compio.git?rev=708499c3f4bb4f57402782b326c7edc7b4fa8b4e#708499c3f4bb4f57402782b326c7edc7b4fa8b4e"
+source = "git+https://github.com/compio-rs/compio.git?rev=54e801c3f17f9c82e79d24be65bd24c5b05056eb#54e801c3f17f9c82e79d24be65bd24c5b05056eb"
 dependencies = [
  "cfg-if",
  "compio-buf",
@@ -239,8 +235,8 @@ dependencies = [
 name = "compio-py"
 version = "0.1.0"
 dependencies = [
- "async-task",
  "compio",
+ "compio-executor",
  "compio-log",
  "once_cell",
  "pem",
@@ -267,7 +263,7 @@ dependencies = [
 [[package]]
 name = "compio-quic"
 version = "0.7.0"
-source = "git+https://github.com/compio-rs/compio.git?rev=708499c3f4bb4f57402782b326c7edc7b4fa8b4e#708499c3f4bb4f57402782b326c7edc7b4fa8b4e"
+source = "git+https://github.com/compio-rs/compio.git?rev=54e801c3f17f9c82e79d24be65bd24c5b05056eb#54e801c3f17f9c82e79d24be65bd24c5b05056eb"
 dependencies = [
  "cfg_aliases",
  "compio-buf",
@@ -289,7 +285,7 @@ dependencies = [
 [[package]]
 name = "compio-runtime"
 version = "0.11.0"
-source = "git+https://github.com/compio-rs/compio.git?rev=708499c3f4bb4f57402782b326c7edc7b4fa8b4e#708499c3f4bb4f57402782b326c7edc7b4fa8b4e"
+source = "git+https://github.com/compio-rs/compio.git?rev=54e801c3f17f9c82e79d24be65bd24c5b05056eb#54e801c3f17f9c82e79d24be65bd24c5b05056eb"
 dependencies = [
  "cfg-if",
  "compio-buf",
@@ -308,14 +304,18 @@ dependencies = [
 
 [[package]]
 name = "compio-send-wrapper"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4b20d9264c5c445ffee1c773b1d5ce7461fea060944424d126ac0853126edf2"
+checksum = "4f1ef3947d751725afe49ab18ce447d819cd8f4ea9b58ae94b8498eb8ad1f864"
+dependencies = [
+ "cfg-if",
+ "loom",
+]
 
 [[package]]
 name = "compio-tls"
 version = "0.9.0"
-source = "git+https://github.com/compio-rs/compio.git?rev=708499c3f4bb4f57402782b326c7edc7b4fa8b4e#708499c3f4bb4f57402782b326c7edc7b4fa8b4e"
+source = "git+https://github.com/compio-rs/compio.git?rev=54e801c3f17f9c82e79d24be65bd24c5b05056eb#54e801c3f17f9c82e79d24be65bd24c5b05056eb"
 dependencies = [
  "compio-buf",
  "compio-io",
@@ -328,7 +328,7 @@ dependencies = [
 [[package]]
 name = "compio-ws"
 version = "0.3.0"
-source = "git+https://github.com/compio-rs/compio.git?rev=708499c3f4bb4f57402782b326c7edc7b4fa8b4e#708499c3f4bb4f57402782b326c7edc7b4fa8b4e"
+source = "git+https://github.com/compio-rs/compio.git?rev=54e801c3f17f9c82e79d24be65bd24c5b05056eb#54e801c3f17f9c82e79d24be65bd24c5b05056eb"
 dependencies = [
  "compio-buf",
  "compio-io",
@@ -387,18 +387,6 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crossfire"
-version = "3.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0042e53977a94d5d10de04ce7eb6016aa212c08e83ea202f7a9f102ff104303"
-dependencies = [
- "crossbeam-utils",
- "futures-core",
- "parking_lot",
- "smallvec",
-]
 
 [[package]]
 name = "crypto-common"
@@ -742,6 +730,8 @@ dependencies = [
  "generator",
  "pin-utils",
  "scoped-tls",
+ "serde",
+ "serde_json",
  "tracing",
  "tracing-subscriber",
 ]
@@ -809,29 +799,6 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-
-[[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
-]
 
 [[package]]
 name = "pastey"
@@ -1085,15 +1052,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1218,6 +1176,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1235,6 +1203,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -1809,3 +1790,9 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,7 +126,7 @@ dependencies = [
 [[package]]
 name = "compio"
 version = "0.18.0"
-source = "git+https://github.com/compio-rs/compio.git?rev=54e801c3f17f9c82e79d24be65bd24c5b05056eb#54e801c3f17f9c82e79d24be65bd24c5b05056eb"
+source = "git+https://github.com/compio-rs/compio.git?rev=8dff845528b2b47f3cc04c302fed0b0edc6c7c91#8dff845528b2b47f3cc04c302fed0b0edc6c7c91"
 dependencies = [
  "compio-buf",
  "compio-driver",
@@ -140,7 +140,7 @@ dependencies = [
 [[package]]
 name = "compio-buf"
 version = "0.8.0"
-source = "git+https://github.com/compio-rs/compio.git?rev=54e801c3f17f9c82e79d24be65bd24c5b05056eb#54e801c3f17f9c82e79d24be65bd24c5b05056eb"
+source = "git+https://github.com/compio-rs/compio.git?rev=8dff845528b2b47f3cc04c302fed0b0edc6c7c91#8dff845528b2b47f3cc04c302fed0b0edc6c7c91"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -150,7 +150,7 @@ dependencies = [
 [[package]]
 name = "compio-driver"
 version = "0.11.1"
-source = "git+https://github.com/compio-rs/compio.git?rev=54e801c3f17f9c82e79d24be65bd24c5b05056eb#54e801c3f17f9c82e79d24be65bd24c5b05056eb"
+source = "git+https://github.com/compio-rs/compio.git?rev=8dff845528b2b47f3cc04c302fed0b0edc6c7c91#8dff845528b2b47f3cc04c302fed0b0edc6c7c91"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -177,7 +177,7 @@ dependencies = [
 [[package]]
 name = "compio-executor"
 version = "0.1.0"
-source = "git+https://github.com/compio-rs/compio.git?rev=54e801c3f17f9c82e79d24be65bd24c5b05056eb#54e801c3f17f9c82e79d24be65bd24c5b05056eb"
+source = "git+https://github.com/compio-rs/compio.git?rev=8dff845528b2b47f3cc04c302fed0b0edc6c7c91#8dff845528b2b47f3cc04c302fed0b0edc6c7c91"
 dependencies = [
  "cfg-if",
  "compio-log",
@@ -190,7 +190,7 @@ dependencies = [
 [[package]]
 name = "compio-io"
 version = "0.9.0"
-source = "git+https://github.com/compio-rs/compio.git?rev=54e801c3f17f9c82e79d24be65bd24c5b05056eb#54e801c3f17f9c82e79d24be65bd24c5b05056eb"
+source = "git+https://github.com/compio-rs/compio.git?rev=8dff845528b2b47f3cc04c302fed0b0edc6c7c91#8dff845528b2b47f3cc04c302fed0b0edc6c7c91"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -206,7 +206,7 @@ dependencies = [
 [[package]]
 name = "compio-log"
 version = "0.1.0"
-source = "git+https://github.com/compio-rs/compio.git?rev=54e801c3f17f9c82e79d24be65bd24c5b05056eb#54e801c3f17f9c82e79d24be65bd24c5b05056eb"
+source = "git+https://github.com/compio-rs/compio.git?rev=8dff845528b2b47f3cc04c302fed0b0edc6c7c91#8dff845528b2b47f3cc04c302fed0b0edc6c7c91"
 dependencies = [
  "tracing",
 ]
@@ -214,7 +214,7 @@ dependencies = [
 [[package]]
 name = "compio-net"
 version = "0.11.0"
-source = "git+https://github.com/compio-rs/compio.git?rev=54e801c3f17f9c82e79d24be65bd24c5b05056eb#54e801c3f17f9c82e79d24be65bd24c5b05056eb"
+source = "git+https://github.com/compio-rs/compio.git?rev=8dff845528b2b47f3cc04c302fed0b0edc6c7c91#8dff845528b2b47f3cc04c302fed0b0edc6c7c91"
 dependencies = [
  "cfg-if",
  "compio-buf",
@@ -263,7 +263,7 @@ dependencies = [
 [[package]]
 name = "compio-quic"
 version = "0.7.0"
-source = "git+https://github.com/compio-rs/compio.git?rev=54e801c3f17f9c82e79d24be65bd24c5b05056eb#54e801c3f17f9c82e79d24be65bd24c5b05056eb"
+source = "git+https://github.com/compio-rs/compio.git?rev=8dff845528b2b47f3cc04c302fed0b0edc6c7c91#8dff845528b2b47f3cc04c302fed0b0edc6c7c91"
 dependencies = [
  "cfg_aliases",
  "compio-buf",
@@ -285,7 +285,7 @@ dependencies = [
 [[package]]
 name = "compio-runtime"
 version = "0.11.0"
-source = "git+https://github.com/compio-rs/compio.git?rev=54e801c3f17f9c82e79d24be65bd24c5b05056eb#54e801c3f17f9c82e79d24be65bd24c5b05056eb"
+source = "git+https://github.com/compio-rs/compio.git?rev=8dff845528b2b47f3cc04c302fed0b0edc6c7c91#8dff845528b2b47f3cc04c302fed0b0edc6c7c91"
 dependencies = [
  "cfg-if",
  "compio-buf",
@@ -315,7 +315,7 @@ dependencies = [
 [[package]]
 name = "compio-tls"
 version = "0.9.0"
-source = "git+https://github.com/compio-rs/compio.git?rev=54e801c3f17f9c82e79d24be65bd24c5b05056eb#54e801c3f17f9c82e79d24be65bd24c5b05056eb"
+source = "git+https://github.com/compio-rs/compio.git?rev=8dff845528b2b47f3cc04c302fed0b0edc6c7c91#8dff845528b2b47f3cc04c302fed0b0edc6c7c91"
 dependencies = [
  "compio-buf",
  "compio-io",
@@ -328,7 +328,7 @@ dependencies = [
 [[package]]
 name = "compio-ws"
 version = "0.3.0"
-source = "git+https://github.com/compio-rs/compio.git?rev=54e801c3f17f9c82e79d24be65bd24c5b05056eb#54e801c3f17f9c82e79d24be65bd24c5b05056eb"
+source = "git+https://github.com/compio-rs/compio.git?rev=8dff845528b2b47f3cc04c302fed0b0edc6c7c91#8dff845528b2b47f3cc04c302fed0b0edc6c7c91"
 dependencies = [
  "compio-buf",
  "compio-io",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,15 +17,15 @@ pyo3 = "0.28.1"
 [workspace.dependencies.compio]
 default-features = false
 git = "https://github.com/compio-rs/compio.git"
-rev = "54e801c3f17f9c82e79d24be65bd24c5b05056eb"
+rev = "8dff845528b2b47f3cc04c302fed0b0edc6c7c91"
 
 [workspace.dependencies.compio-executor]
 git = "https://github.com/compio-rs/compio.git"
-rev = "54e801c3f17f9c82e79d24be65bd24c5b05056eb"
+rev = "8dff845528b2b47f3cc04c302fed0b0edc6c7c91"
 
 [workspace.dependencies.compio-log]
 git = "https://github.com/compio-rs/compio.git"
-rev = "54e801c3f17f9c82e79d24be65bd24c5b05056eb"
+rev = "8dff845528b2b47f3cc04c302fed0b0edc6c7c91"
 
 [patch.crates-io]
 compio-py-dynamic-openssl = { path = "compio-py-dynamic-openssl" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,15 @@ pyo3 = "0.28.1"
 [workspace.dependencies.compio]
 default-features = false
 git = "https://github.com/compio-rs/compio.git"
-rev = "708499c3f4bb4f57402782b326c7edc7b4fa8b4e"
+rev = "54e801c3f17f9c82e79d24be65bd24c5b05056eb"
+
+[workspace.dependencies.compio-executor]
+git = "https://github.com/compio-rs/compio.git"
+rev = "54e801c3f17f9c82e79d24be65bd24c5b05056eb"
 
 [workspace.dependencies.compio-log]
 git = "https://github.com/compio-rs/compio.git"
-rev = "708499c3f4bb4f57402782b326c7edc7b4fa8b4e"
+rev = "54e801c3f17f9c82e79d24be65bd24c5b05056eb"
 
 [patch.crates-io]
 compio-py-dynamic-openssl = { path = "compio-py-dynamic-openssl" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,11 @@ pyo3 = "0.28.1"
 [workspace.dependencies.compio]
 default-features = false
 git = "https://github.com/compio-rs/compio.git"
-rev = "92127da50b383be53f7a5364ee818bf3952ac17f"
+rev = "708499c3f4bb4f57402782b326c7edc7b4fa8b4e"
 
 [workspace.dependencies.compio-log]
 git = "https://github.com/compio-rs/compio.git"
-rev = "92127da50b383be53f7a5364ee818bf3952ac17f"
+rev = "708499c3f4bb4f57402782b326c7edc7b4fa8b4e"
 
 [patch.crates-io]
 compio-py-dynamic-openssl = { path = "compio-py-dynamic-openssl" }

--- a/compio-py/Cargo.toml
+++ b/compio-py/Cargo.toml
@@ -20,11 +20,11 @@ enable_log = ["compio/enable_log", "tracing-subscriber"]
 pyo3 = { workspace = true, features = ["extension-module"] }
 once_cell = "1.21.3"
 scoped-tls = "1.0.1"
-async-task = { version = "4.7.1", default-features = false }
 tracing-subscriber = { version = "0.3", optional = true, features = ["env-filter"] }
 socket2 = "0.6.2"
 rustls-webpki = "0"
 pem = "3.0.6"
 pkcs8 = { version = "0.10.2", features = ["encryption"] }
 compio = { workspace = true, features = ["io-uring", "polling", "io", "py-dynamic-openssl", "rustls", "ring"] }
+compio-executor = { workspace = true }
 compio-log = { workspace = true }

--- a/compio-py/src/event_loop.rs
+++ b/compio-py/src/event_loop.rs
@@ -205,12 +205,13 @@ impl CompioLoop {
     // Completion based I/O methods returning Futures.
 
     fn sock_recv_into<'py>(
-        &self,
+        slf: &Bound<Self>,
         py: Python<'py>,
         sock: Py<PyAny>,
         buf: Py<PyAny>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        self.spawn_py(py, async {
+        let this = slf.clone().unbind();
+        slf.borrow().spawn_py(py, async move {
             let op = Python::attach(|py| {
                 let pybuf: PyBuffer<u8> = PyBuffer::get(buf.bind(py))?;
                 if pybuf.readonly() {
@@ -227,7 +228,7 @@ impl CompioLoop {
                 let len = pybuf.len_bytes();
                 let buf = unsafe { std::slice::from_raw_parts_mut(ptr, len) };
 
-                let fd = self.socket_to_fd(py, &sock)?;
+                let fd = this.bind(py).borrow().socket_to_fd(py, &sock)?;
                 Ok(Recv::new(fd, buf, 0))
             })?;
             let nbytes = runtime::execute(op).await.0?;
@@ -287,7 +288,7 @@ impl CompioLoop {
     /// When the Python Future is cancelled, the Rust Future is also cancelled.
     pub fn spawn_py<'py, F>(&self, py: Python<'py>, fut: F) -> PyResult<Bound<'py, PyAny>>
     where
-        F: Future<Output = PyResult<Py<PyAny>>>,
+        F: Future<Output = PyResult<Py<PyAny>>> + 'static,
     {
         let cancellable = Bound::new(py, Cancellable { task: None })?;
         let rv = COMPIO_FUTURE

--- a/compio-py/src/event_loop.rs
+++ b/compio-py/src/event_loop.rs
@@ -6,8 +6,8 @@ use std::sync::{
     atomic::{self, AtomicBool},
 };
 
-use async_task::Task;
 use compio::driver::{SharedFd, ToSharedFd, op::Recv};
+use compio_executor::JoinHandle;
 use compio_log::*;
 use once_cell::sync::OnceCell;
 use pyo3::{
@@ -299,7 +299,7 @@ impl CompioLoop {
 
         let py_fut: Py<PyAny> = rv.clone().unbind();
         let cancellable_py = cancellable.clone().unbind();
-        let task = self.runtime()?.spawn(async move {
+        let join_handle = self.runtime()?.spawn(async move {
             let result = fut.await;
             Python::attach(|py| {
                 let py_fut = py_fut.bind(py);
@@ -329,7 +329,7 @@ impl CompioLoop {
                 }
             })
         });
-        cancellable.borrow_mut().task.replace(task);
+        cancellable.borrow_mut().task.replace(join_handle);
         Ok(rv)
     }
 
@@ -347,9 +347,9 @@ impl CompioLoop {
     }
 }
 
-#[pyclass]
+#[pyclass(unsendable)]
 struct Cancellable {
-    task: Option<Task<()>>,
+    task: Option<JoinHandle<()>>,
 }
 
 #[pymethods]

--- a/compio-py/src/handle.rs
+++ b/compio-py/src/handle.rs
@@ -3,7 +3,7 @@
 
 use std::iter;
 
-use async_task::Task;
+use compio_executor::JoinHandle;
 use pyo3::{
     exceptions::{PyKeyboardInterrupt, PySystemExit},
     prelude::*,
@@ -13,12 +13,12 @@ use pyo3::{
 
 use crate::{import, runtime, runtime::Runtime};
 
-#[pyclass(subclass, weakref)]
+#[pyclass(subclass, weakref, unsendable)]
 pub struct Handle {
     callback: Py<PyAny>,
     args: Py<PyTuple>,
     context: Py<PyAny>,
-    task: Option<Task<()>>,
+    task: Option<JoinHandle<()>>,
 }
 
 impl Handle {

--- a/compio-py/src/runtime.rs
+++ b/compio-py/src/runtime.rs
@@ -362,7 +362,6 @@ impl Drop for Runtime {
             key.waker.wake();
             trace!("Drop TimerKey");
         }
-        self.executor.clear();
     }
 }
 

--- a/compio-py/src/runtime.rs
+++ b/compio-py/src/runtime.rs
@@ -238,7 +238,7 @@ impl Runtime {
 
     pub fn spawn<F>(&self, fut: F) -> Task<F::Output>
     where
-        F: Future,
+        F: Future + 'static,
     {
         let schedule = |runnable| {
             self.ready.borrow_mut().push_back(runnable);

--- a/compio-py/src/runtime.rs
+++ b/compio-py/src/runtime.rs
@@ -4,7 +4,7 @@
 use std::{
     cell::RefCell,
     cmp,
-    collections::{BinaryHeap, VecDeque},
+    collections::BinaryHeap,
     io,
     ops::Deref,
     panic,
@@ -18,7 +18,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-use async_task::{Runnable, Task};
 use compio::{
     BufResult,
     buf::IntoInner,
@@ -27,6 +26,7 @@ use compio::{
         op::Asyncify,
     },
 };
+use compio_executor::{Executor, JoinHandle};
 use compio_log::*;
 use pyo3::{exceptions::PyRuntimeError, prelude::*, types::PyDict, types::PyWeakrefReference};
 
@@ -185,7 +185,7 @@ impl Future for Timer {
 
 impl Drop for Timer {
     fn drop(&mut self) {
-        trace!("Timer cancelled");
+        trace!("Timer dropped");
         if self
             .cancelled
             .compare_exchange(
@@ -197,7 +197,6 @@ impl Drop for Timer {
             .is_ok()
             && self.scheduled
         {
-            debug!("Timer cancelled counted");
             self.timer_cancelled_count
                 .fetch_add(1, atomic::Ordering::Release);
         }
@@ -209,7 +208,7 @@ pub struct Runtime {
     epoch: Instant,
     stopping: Arc<AtomicBool>,
     driver: RefCell<Proactor>,
-    ready: RefCell<VecDeque<Runnable>>,
+    executor: Executor,
     scheduled: RefCell<BinaryHeap<TimerKey>>,
     fatal_error: RefCell<Option<PyErr>>,
     timer_cancelled_count: Arc<AtomicUsize>,
@@ -225,7 +224,7 @@ impl Runtime {
             epoch: Instant::now(),
             stopping,
             driver: RefCell::new(driver),
-            ready: RefCell::new(VecDeque::new()),
+            executor: Executor::new(),
             scheduled: RefCell::new(BinaryHeap::new()),
             fatal_error: RefCell::new(None),
             timer_cancelled_count: Arc::new(AtomicUsize::new(0)),
@@ -236,16 +235,11 @@ impl Runtime {
         self.driver.borrow().driver_type()
     }
 
-    pub fn spawn<F>(&self, fut: F) -> Task<F::Output>
+    pub fn spawn<F>(&self, fut: F) -> JoinHandle<F::Output>
     where
         F: Future + 'static,
     {
-        let schedule = |runnable| {
-            self.ready.borrow_mut().push_back(runnable);
-        };
-        let (runnable, task) = unsafe { async_task::spawn_unchecked(fut, schedule) };
-        runnable.schedule();
-        task
+        self.executor.spawn(fut)
     }
 
     #[inline]
@@ -290,19 +284,23 @@ impl Runtime {
             }
         }
 
-        let timeout =
-            if !self.ready.borrow().is_empty() || self.stopping.load(atomic::Ordering::Acquire) {
-                Some(Duration::default())
-            } else if let Some(next_scheduled) = self.scheduled.borrow().peek() {
-                Some(
-                    next_scheduled
-                        .when
-                        .saturating_duration_since(Instant::now())
-                        .min(MAXIMUM_SELECT_TIMEOUT),
-                )
-            } else {
-                None
-            };
+        let remaining_tasks = self.executor.tick();
+        if let Some(err) = self.fatal_error.take() {
+            return Err(err);
+        }
+
+        let timeout = if remaining_tasks || self.stopping.load(atomic::Ordering::Acquire) {
+            Some(Duration::default())
+        } else if let Some(next_scheduled) = self.scheduled.borrow().peek() {
+            Some(
+                next_scheduled
+                    .when
+                    .saturating_duration_since(Instant::now())
+                    .min(MAXIMUM_SELECT_TIMEOUT),
+            )
+        } else {
+            None
+        };
         debug!("Polling I/O with timeout {:?}", timeout);
         self.driver
             .borrow_mut()
@@ -324,22 +322,6 @@ impl Runtime {
                     }
                     _ => break,
                 }
-            }
-        }
-
-        // This is the only place where callbacks are actually *called*.
-        // All other places just add them to ready.
-        // Note: We run all currently scheduled callbacks, but not any
-        // callbacks scheduled by callbacks run this time around --
-        // they will be run the next time (after another I/O poll).
-        // Use an idiom that is thread-safe without using locks.
-        let ntodo = self.ready.borrow().len();
-        debug!("Ready handles to run: {}", ntodo);
-        for _ in 0..ntodo {
-            let runnable = self.ready.borrow_mut().pop_front().expect("not empty");
-            runnable.run();
-            if let Some(err) = self.fatal_error.take() {
-                return Err(err);
             }
         }
 
@@ -380,7 +362,7 @@ impl Drop for Runtime {
             key.waker.wake();
             trace!("Drop TimerKey");
         }
-        self.ready.take();
+        self.executor.clear();
     }
 }
 

--- a/compio-py/src/socket.rs
+++ b/compio-py/src/socket.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use compio::{
-    buf::{BufResult, IntoInner, IoBuf, IoBufMut, buf_try},
+    buf::{BufResult, IntoInner, IoBuf, IoBufMut, IoVectoredBufMut, buf_try},
     driver::{
         AsRawFd, ToSharedFd, impl_raw_fd,
         op::{BufResultExt, CloseSocket, Connect, Recv, Send, ShutdownSocket},
@@ -306,14 +306,14 @@ pub struct SocketStream {
     inner: Socket,
 }
 
-impl AsyncRead for SocketStream {
+impl AsyncRead for &SocketStream {
     #[inline]
     async fn read<B: IoBufMut>(&mut self, buf: B) -> BufResult<usize, B> {
         self.inner.recv(buf, 0).await
     }
 }
 
-impl AsyncWrite for SocketStream {
+impl AsyncWrite for &SocketStream {
     async fn write<T: IoBuf>(&mut self, buf: T) -> BufResult<usize, T> {
         self.inner.send(buf, 0).await
     }
@@ -324,6 +324,32 @@ impl AsyncWrite for SocketStream {
 
     async fn shutdown(&mut self) -> io::Result<()> {
         self.inner.shutdown(Shutdown::Write).await
+    }
+}
+
+impl AsyncRead for SocketStream {
+    #[inline]
+    async fn read<B: IoBufMut>(&mut self, buf: B) -> BufResult<usize, B> {
+        (&*self).read(buf).await
+    }
+
+    #[inline]
+    async fn read_vectored<V: IoVectoredBufMut>(&mut self, buf: V) -> BufResult<usize, V> {
+        (&*self).read_vectored(buf).await
+    }
+}
+
+impl AsyncWrite for SocketStream {
+    async fn write<T: IoBuf>(&mut self, buf: T) -> BufResult<usize, T> {
+        (&*self).write(buf).await
+    }
+
+    async fn flush(&mut self) -> io::Result<()> {
+        (&*self).flush().await
+    }
+
+    async fn shutdown(&mut self) -> io::Result<()> {
+        (&*self).shutdown().await
     }
 }
 

--- a/compio-py/src/socket.rs
+++ b/compio-py/src/socket.rs
@@ -11,7 +11,7 @@ use compio::{
     buf::{BufResult, IntoInner, IoBuf, IoBufMut, IoVectoredBufMut, buf_try},
     driver::{
         AsRawFd, ToSharedFd, impl_raw_fd,
-        op::{BufResultExt, CloseSocket, Connect, Recv, Send, ShutdownSocket},
+        op::{self, BufResultExt},
     },
     io::{AsyncRead, AsyncWrite},
     tls::{
@@ -462,7 +462,7 @@ impl Socket {
     }
 
     async fn connect_async(&self, addr: &SockAddr) -> io::Result<()> {
-        let op = Connect::new(self.to_shared_fd(), addr.clone());
+        let op = op::Connect::new(self.to_shared_fd(), addr.clone());
         let (_, _op) = buf_try!(@try runtime::execute(op).await);
         #[cfg(windows)]
         _op.update_context()?;
@@ -471,28 +471,33 @@ impl Socket {
 
     async fn recv<B: IoBufMut>(&self, buffer: B, flags: i32) -> BufResult<usize, B> {
         let fd = self.to_shared_fd();
-        let op = Recv::new(fd, buffer, flags);
+        let op = op::Recv::new(fd, buffer, flags);
         let res = runtime::execute(op).await.into_inner();
         unsafe { res.map_advanced() }
     }
 
     async fn send<T: IoBuf>(&self, buffer: T, flags: i32) -> BufResult<usize, T> {
         let fd = self.to_shared_fd();
-        let op = Send::new(fd, buffer, flags);
+        let op = op::Send::new(fd, buffer, flags);
         runtime::execute(op).await.into_inner()
     }
 
     async fn shutdown(&self, how: Shutdown) -> io::Result<()> {
-        let fd = self.to_shared_fd();
-        let op = ShutdownSocket::new(fd, how);
-        runtime::execute(op).await.0?;
-        Ok(())
+        #[cfg(unix)]
+        {
+            let fd = self.to_shared_fd();
+            let op = op::ShutdownSocket::new(fd, how);
+            runtime::execute(op).await.0?;
+            Ok(())
+        }
+        #[cfg(windows)]
+        self.socket.shutdown(how)
     }
 
     async fn close(self) -> io::Result<()> {
         let fd = self.socket.into_inner().take().await;
         if let Some(fd) = fd {
-            let op = CloseSocket::new(fd.into());
+            let op = op::CloseSocket::new(fd.into());
             runtime::execute(op).await.0?;
         }
         Ok(())

--- a/compio-py/src/socket.rs
+++ b/compio-py/src/socket.rs
@@ -102,12 +102,19 @@ impl PySocket {
     }
 
     #[pyo3(signature = (address, /))]
-    fn connect<'py>(&mut self, py: Python<'py>, address: Py<PyAny>) -> PyResult<Bound<'py, PyAny>> {
-        self.pyloop.bind(py).borrow().spawn_py(py, async move {
-            let Some(inner) = &self.inner else {
-                return Err(PyOSError::new_err("socket is closed"));
-            };
-            match self.domain {
+    fn connect<'py>(
+        slf: &Bound<'py, Self>,
+        py: Python<'py>,
+        address: Py<PyAny>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let this = slf.clone().unbind();
+        let slf = slf.borrow().pyloop.bind(py).borrow();
+        slf.spawn_py(py, async move {
+            let (domain, inner) = Python::attach(|py| {
+                let this = this.bind(py).borrow();
+                this.inner().cloned().map(|inner| (this.domain, inner))
+            })?;
+            match domain {
                 Domain::IPV4 => {
                     let (result, port) = Python::attach(|py| {
                         let (host, port): (Bound<PyAny>, u16) = address.extract(py)?;
@@ -121,33 +128,37 @@ impl PySocket {
                     })?;
                     let ip = match result {
                         Ok(ip) => ip,
-                        Err(name) => name_to_ip(name, self.domain).await?.parse()?,
+                        Err(name) => name_to_ip(name, domain).await?.parse()?,
                     };
-                    if cfg!(windows) && !self.bound {
+                    if cfg!(windows) && !Python::attach(|py| this.bind(py).borrow().bound) {
                         inner
                             .socket
                             .bind(&SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0).into())?;
-                        self.bound = true;
+                        Python::attach(|py| this.bind(py).borrow_mut().bound = true);
                     }
                     let addr = SocketAddr::new(ip.into(), port).into();
                     inner.connect_async(&addr).await?;
-                    self.bound = true;
                 }
                 _ => unimplemented!(),
             };
-            Python::attach(|py| py.None().into_py_any(py))
+            Python::attach(|py| {
+                this.bind(py).borrow_mut().bound = true;
+                py.None().into_py_any(py)
+            })
         })
     }
 
     #[pyo3(signature = (bufsize, flags = 0, /))]
     fn recv<'py>(
-        &self,
+        slf: &Bound<Self>,
         py: Python<'py>,
         bufsize: usize,
         flags: i32,
     ) -> PyResult<Bound<'py, PyAny>> {
-        self.pyloop.bind(py).borrow().spawn_py(py, async move {
-            let inner = self.inner()?;
+        let this = slf.clone().unbind();
+        let slf = slf.borrow().pyloop.bind(py).borrow();
+        slf.spawn_py(py, async move {
+            let inner = Python::attach(|py| this.bind(py).borrow().inner().cloned())?;
             let buf: Vec<u8> = Vec::with_capacity(bufsize);
             let (bytes_read, buf) = buf_try!(@try inner.recv(buf, flags).await);
             Python::attach(|py| {
@@ -159,14 +170,18 @@ impl PySocket {
 
     #[pyo3(signature = (data, flags = 0, /))]
     fn send<'py>(
-        &self,
+        slf: &Bound<Self>,
         py: Python<'py>,
         data: Py<PyAny>,
         flags: i32,
     ) -> PyResult<Bound<'py, PyAny>> {
-        self.pyloop.bind(py).borrow().spawn_py(py, async move {
-            let inner = self.inner()?;
-            let buf = Python::attach(|py| py_any_to_buffer(py, data.bind(py)))?;
+        let this = slf.clone().unbind();
+        let slf = slf.borrow().pyloop.bind(py).borrow();
+        slf.spawn_py(py, async move {
+            let (inner, buf) = Python::attach(|py| {
+                let inner = this.bind(py).borrow().inner()?.clone();
+                py_any_to_buffer(py, data.bind(py)).map(|buf| (inner, buf))
+            })?;
             let (bytes_written, _) = buf_try!(@try inner.send(buf, flags).await);
             drop(data);
             Python::attach(|py| bytes_written.into_py_any(py))
@@ -175,13 +190,15 @@ impl PySocket {
 
     #[pyo3(signature = (sslcontext=None, *, server_side=false, server_hostname=None))]
     fn start_tls<'py>(
-        &mut self,
+        slf: &Bound<Self>,
         py: Python<'py>,
         sslcontext: Option<Py<PyAny>>,
         server_side: bool,
         server_hostname: Option<String>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        self.pyloop.bind(py).borrow().spawn_py(py, async move {
+        let this = slf.clone().unbind();
+        let slf = slf.borrow().pyloop.bind(py).borrow();
+        slf.spawn_py(py, async move {
             let mut metadata = SSLSocketMetadata::default();
             metadata.server_side = server_side;
 
@@ -241,7 +258,7 @@ impl PySocket {
             })?;
 
             // Then, do TLS handshake accordingly
-            let Some(inner) = self.inner.take() else {
+            let Some(inner) = Python::attach(|py| this.bind(py).borrow_mut().inner.take()) else {
                 return Err(PyOSError::new_err("socket is closed"));
             };
             metadata.fd = inner.as_raw_fd();
@@ -265,35 +282,43 @@ impl PySocket {
             };
 
             // At last, wrap the TlsStream in an SSLSocket
-            Python::attach(|py| SSLSocket::new(py, &self.pyloop, stream, metadata)?.into_py_any(py))
+            Python::attach(|py| {
+                let this = this.bind(py).borrow();
+                SSLSocket::new(py, &this.pyloop, stream, metadata)?.into_py_any(py)
+            })
         })
     }
 
     #[pyo3(signature = (how, /))]
-    fn shutdown<'py>(&self, py: Python<'py>, how: i32) -> PyResult<Bound<'py, PyAny>> {
-        self.pyloop.bind(py).borrow().spawn_py(py, async move {
-            let inner = self.inner()?;
-            let how = Python::attach(|py| {
-                if how == import::socket::shut_wr(py)? {
-                    Ok(Shutdown::Write)
+    fn shutdown<'py>(slf: &Bound<Self>, py: Python<'py>, how: i32) -> PyResult<Bound<'py, PyAny>> {
+        let this = slf.clone().unbind();
+        let slf = slf.borrow().pyloop.bind(py).borrow();
+        slf.spawn_py(py, async move {
+            let (inner, how) = Python::attach(|py| {
+                let inner = this.bind(py).borrow().inner()?.clone();
+                let how = if how == import::socket::shut_wr(py)? {
+                    Shutdown::Write
                 } else if how == import::socket::shut_rd(py)? {
-                    Ok(Shutdown::Read)
+                    Shutdown::Read
                 } else if how == import::socket::shut_rdwr(py)? {
-                    Ok(Shutdown::Both)
+                    Shutdown::Both
                 } else {
                     return Err(PyValueError::new_err(format!(
                         "invalid shutdown how: {how}"
                     )));
-                }
+                };
+                Ok((inner, how))
             })?;
             inner.shutdown(how).await?;
             Python::attach(|py| py.None().into_py_any(py))
         })
     }
 
-    fn close<'py>(&mut self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        self.pyloop.bind(py).borrow().spawn_py(py, async move {
-            if let Some(inner) = self.inner.take() {
+    fn close<'py>(slf: &Bound<'py, Self>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let this = slf.clone().unbind();
+        let slf = slf.borrow().pyloop.bind(py).borrow();
+        slf.spawn_py(py, async move {
+            if let Some(inner) = Python::attach(|py| this.bind(py).borrow_mut().inner.take()) {
                 inner.close().await?;
             };
             Python::attach(|py| py.None().into_py_any(py))

--- a/compio-py/src/ssl.rs
+++ b/compio-py/src/ssl.rs
@@ -3,7 +3,9 @@
 
 use std::{
     borrow::Cow,
+    cell::{self, RefCell},
     fmt, io, iter,
+    rc::Rc,
     sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard},
 };
 
@@ -59,7 +61,7 @@ pub struct SSLSocketMetadata {
 #[pyclass(unsendable)]
 pub struct SSLSocket {
     pyloop: Py<CompioLoop>,
-    inner: Option<TlsStream<SocketStream>>,
+    inner: SSLSocketInner,
     metadata: SSLSocketMetadata,
 }
 
@@ -74,31 +76,20 @@ impl SSLSocket {
             py,
             Self {
                 pyloop: pyloop.clone_ref(py),
-                inner: Some(stream),
+                inner: SSLSocketInner::new(stream),
                 metadata,
             },
         )
-    }
-
-    fn inner(&self) -> PyResult<&TlsStream<SocketStream>> {
-        self.inner
-            .as_ref()
-            .ok_or_else(|| PyOSError::new_err("socket is closed"))
-    }
-
-    fn inner_mut(&mut self) -> PyResult<&mut TlsStream<SocketStream>> {
-        self.inner
-            .as_mut()
-            .ok_or_else(|| PyOSError::new_err("socket is closed"))
     }
 }
 
 #[pymethods]
 impl SSLSocket {
     #[pyo3(signature = (bufsize, /))]
-    fn recv<'py>(&mut self, py: Python<'py>, bufsize: usize) -> PyResult<Bound<'py, PyAny>> {
+    fn recv<'py>(&self, py: Python<'py>, bufsize: usize) -> PyResult<Bound<'py, PyAny>> {
+        let inner = self.inner.clone();
         self.pyloop.bind(py).borrow().spawn_py(py, async move {
-            let inner = self.inner_mut()?;
+            let mut inner = inner.borrow_mut()?;
             let buf = Vec::with_capacity(bufsize);
             let (bytes_read, buf) = buf_try!(@try inner.read(buf).await);
             Python::attach(|py| {
@@ -110,8 +101,9 @@ impl SSLSocket {
 
     #[pyo3(signature = (data, /))]
     fn send<'py>(&mut self, py: Python<'py>, data: Py<PyAny>) -> PyResult<Bound<'py, PyAny>> {
+        let inner = self.inner.clone();
         self.pyloop.bind(py).borrow().spawn_py(py, async move {
-            let inner = self.inner_mut()?;
+            let mut inner = inner.borrow_mut()?;
             let buf = Python::attach(|py| py_any_to_buffer(py, data.bind(py)))?;
             let (bytes_written, _) = buf_try!(@try inner.write(buf).await);
             drop(data);
@@ -121,8 +113,9 @@ impl SSLSocket {
     }
 
     fn close<'py>(&mut self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let inner = self.inner.clone();
         self.pyloop.bind(py).borrow().spawn_py(py, async move {
-            if let Some(mut inner) = self.inner.take()
+            if let Some(mut inner) = inner.borrow_mut_opt()?.take()
                 && let Err(e) = inner.shutdown().await
                 && e.kind() != io::ErrorKind::WouldBlock
             {
@@ -132,18 +125,53 @@ impl SSLSocket {
         })
     }
 
-    fn negotiated_alpn(&'_ self) -> PyResult<Option<Cow<'_, [u8]>>> {
-        Ok(self.inner()?.negotiated_alpn())
+    fn negotiated_alpn(&self) -> PyResult<Option<Vec<u8>>> {
+        Ok(self.inner.borrow()?.negotiated_alpn().map(|x| x.to_vec()))
     }
 
-    fn __repr__(&self) -> String {
-        match &self.inner {
+    fn __repr__(&self) -> PyResult<String> {
+        Ok(match self.inner.borrow_opt()?.as_ref() {
             Some(_) => format!(
                 "<compio.SSLSocket impl={:?}, server_side={}, fd={:?}>",
                 self.metadata.implementation, self.metadata.server_side, self.metadata.fd,
             ),
             None => "<compio.SSLSocket (closed)>".to_string(),
-        }
+        })
+    }
+}
+
+#[derive(Clone)]
+struct SSLSocketInner(Rc<RefCell<Option<TlsStream<SocketStream>>>>);
+
+impl SSLSocketInner {
+    fn new(stream: TlsStream<SocketStream>) -> Self {
+        Self(Rc::new(RefCell::new(Some(stream))))
+    }
+
+    #[inline]
+    fn borrow_opt(&self) -> PyResult<cell::Ref<'_, Option<TlsStream<SocketStream>>>> {
+        self.0
+            .try_borrow()
+            .map_err(|_| PyRuntimeError::new_err("concurrent access to SSLSocket"))
+    }
+
+    #[inline]
+    fn borrow(&self) -> PyResult<cell::Ref<'_, TlsStream<SocketStream>>> {
+        cell::Ref::filter_map(self.borrow_opt()?, |rv| rv.as_ref())
+            .map_err(|_| PyOSError::new_err("socket is closed"))
+    }
+
+    #[inline]
+    fn borrow_mut_opt(&self) -> PyResult<cell::RefMut<'_, Option<TlsStream<SocketStream>>>> {
+        self.0
+            .try_borrow_mut()
+            .map_err(|_| PyRuntimeError::new_err("concurrent access to SSLSocket"))
+    }
+
+    #[inline]
+    fn borrow_mut(&self) -> PyResult<cell::RefMut<'_, TlsStream<SocketStream>>> {
+        cell::RefMut::filter_map(self.borrow_mut_opt()?, |rv| rv.as_mut())
+            .map_err(|_| PyOSError::new_err("socket is closed"))
     }
 }
 

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -46,7 +46,13 @@ def has_io_uring_support() -> bool:
         return False
 
 
-class TestCompioLoop(unittest.TestCase):
+class TestCase(unittest.TestCase):
+    def tearDown(self) -> None:
+        gc.collect()
+        super().tearDown()
+
+
+class TestCompioLoop(TestCase):
     def test_create_loop(self) -> None:
         """Test that a CompioLoop can be created."""
         loop = compio.CompioLoop()
@@ -109,7 +115,7 @@ class TestCompioLoop(unittest.TestCase):
         )
 
 
-class TestLoopState(unittest.TestCase):
+class TestLoopState(TestCase):
     def test_initial_state(self) -> None:
         """Test initial state of a new loop."""
         loop = compio.CompioLoop()
@@ -142,7 +148,7 @@ class TestLoopState(unittest.TestCase):
             loop.call_soon(lambda: None)
 
 
-class TestCallSoon(unittest.TestCase):
+class TestCallSoon(TestCase):
     def test_call_soon_returns_handle(self) -> None:
         """Test that call_soon returns a Handle."""
         loop = compio.CompioLoop()
@@ -179,7 +185,7 @@ class TestCallSoon(unittest.TestCase):
         loop.close()
 
 
-class TestHandle(unittest.TestCase):
+class TestHandle(TestCase):
     def test_handle_cancel(self) -> None:
         """Test that cancelled handle's callback is not executed."""
         loop = compio.CompioLoop()
@@ -215,7 +221,7 @@ class TestHandle(unittest.TestCase):
         loop.close()
 
 
-class TestRunForever(unittest.TestCase):
+class TestRunForever(TestCase):
     def test_run_forever_and_stop(self) -> None:
         """Test run_forever stops when stop is called."""
         loop = compio.CompioLoop()
@@ -298,7 +304,7 @@ class TestRunForever(unittest.TestCase):
         loop.close()
 
 
-class TestContextVars(unittest.TestCase):
+class TestContextVars(TestCase):
     def test_call_soon_copies_context(self) -> None:
         """Test that call_soon copies current context."""
         loop = compio.CompioLoop()
@@ -344,7 +350,7 @@ class TestContextVars(unittest.TestCase):
         loop.close()
 
 
-class TestClose(unittest.TestCase):
+class TestClose(TestCase):
     def test_cannot_close_running_loop(self) -> None:
         """Test that closing a running loop raises RuntimeError."""
         loop = compio.CompioLoop()
@@ -365,7 +371,7 @@ class TestClose(unittest.TestCase):
         loop.close()
 
 
-class TestRepr(unittest.TestCase):
+class TestRepr(TestCase):
     def test_repr_shows_running_state(self) -> None:
         """Test that repr shows running state correctly."""
         loop = compio.CompioLoop()
@@ -397,7 +403,7 @@ class TestRepr(unittest.TestCase):
         self.assertIn("closed=True", repr_after)
 
 
-class TestTime(unittest.TestCase):
+class TestTime(TestCase):
     def test_time_returns_float(self) -> None:
         """Test that time() returns a float."""
         loop = compio.CompioLoop()
@@ -415,7 +421,7 @@ class TestTime(unittest.TestCase):
         loop.close()
 
 
-class TestCallLater(unittest.TestCase):
+class TestCallLater(TestCase):
     def test_call_later_returns_timer_handle(self) -> None:
         """Test that call_later returns a TimerHandle."""
         loop = compio.CompioLoop()
@@ -479,7 +485,7 @@ class TestCallLater(unittest.TestCase):
         loop.close()
 
 
-class TestCallAt(unittest.TestCase):
+class TestCallAt(TestCase):
     def test_call_at_returns_timer_handle(self) -> None:
         """Test that call_at returns a TimerHandle."""
         loop = compio.CompioLoop()
@@ -531,7 +537,7 @@ class TestCallAt(unittest.TestCase):
         loop.close()
 
 
-class TestTimerHandle(unittest.TestCase):
+class TestTimerHandle(TestCase):
     def test_timer_handle_when(self) -> None:
         """Test that TimerHandle.when() returns scheduled time."""
         loop = compio.CompioLoop()
@@ -592,7 +598,7 @@ class TestTimerHandle(unittest.TestCase):
         loop.close()
 
 
-class TestTimerHandleCancellation(unittest.TestCase):
+class TestTimerHandleCancellation(TestCase):
     def test_mass_cancel_cleanup(self) -> None:
         """Test that mass cancellation of timers triggers cleanup."""
         loop = compio.CompioLoop()
@@ -658,7 +664,7 @@ class TestTimerHandleCancellation(unittest.TestCase):
         loop.close()
 
 
-class TestCallLaterContextVars(unittest.TestCase):
+class TestCallLaterContextVars(TestCase):
     def test_call_later_copies_context(self) -> None:
         """Test that call_later copies current context."""
         loop = compio.CompioLoop()
@@ -706,7 +712,7 @@ class TestCallLaterContextVars(unittest.TestCase):
 
 
 if sys.version_info >= (3, 12):
-    class TestHandleGetContext(unittest.TestCase):
+    class TestHandleGetContext(TestCase):
         def test_get_context_returns_context(self) -> None:
             """Test that Handle.get_context() returns the context."""
             loop = compio.CompioLoop()
@@ -750,7 +756,7 @@ if sys.version_info >= (3, 12):
             loop.close()
 
 
-class TestExceptionHandler(unittest.TestCase):
+class TestExceptionHandler(TestCase):
     def test_get_exception_handler_default(self) -> None:
         """Test that get_exception_handler returns None by default."""
         loop = compio.CompioLoop()
@@ -920,7 +926,7 @@ class TestExceptionHandler(unittest.TestCase):
         loop.close()
 
 
-class TestCallLaterExceptions(unittest.TestCase):
+class TestCallLaterExceptions(TestCase):
     def test_exception_in_timer_callback(self) -> None:
         """Test that exceptions in timer callbacks invoke exception handler."""
         loop = compio.CompioLoop()


### PR DESCRIPTION
Depends on compio-rs/compio#840, compio-rs/compio#850

This also fixes a safety issue that, `spawn_unchecked()` was allowing multiple mutable borrows in different places.